### PR TITLE
chore(spotless.gradle.kts): update Spotless configuration to include specific editorConfig settings and target file patterns

### DIFF
--- a/build-plugins/src/main/kotlin/io.ashdavies.spotless.gradle.kts
+++ b/build-plugins/src/main/kotlin/io.ashdavies.spotless.gradle.kts
@@ -6,29 +6,30 @@ plugins {
 
 spotless {
     val ktLintVersion = libs.versions.pinterest.ktlint.get()
-    fun FormatExtension.kotlinDefault(extension: String = "kt") {
-        target("**/src/**/*.$extension")
+    val editorConfig = mapOf(
+        "ij_kotlin_allow_trailing_comma_on_call_site" to "true",
+        "ktlint_standard_function-naming" to "disabled",
+        "ij_kotlin_allow_trailing_comma" to "true",
+        "ktlint_experimental" to "enabled",
+        "ktlint_filename" to "disabled",
+        "android" to "true",
+    )
+
+    fun FormatExtension.kotlinDefault(target: String) {
         targetExclude("**/build/**")
+        target("**/src/**/$target")
         trimTrailingWhitespace()
         endWithNewline()
     }
 
     kotlinGradle {
-        kotlinDefault("gradle.kts")
-        ktlint(ktLintVersion)
+        ktlint(ktLintVersion).editorConfigOverride(editorConfig)
+        kotlinDefault("*.gradle.kts")
     }
 
     kotlin {
-        val editorConfig = mapOf(
-            "ij_kotlin_allow_trailing_comma_on_call_site" to "true",
-            "ij_kotlin_allow_trailing_comma" to "true",
-            "ktlint_experimental" to "enabled",
-            "disabled_rules" to "filename",
-            "android" to "true",
-        )
-
         ktlint(ktLintVersion).editorConfigOverride(editorConfig)
-        kotlinDefault()
+        kotlinDefault("*.kt")
     }
 
     format("misc") {


### PR DESCRIPTION
The Spotless configuration in `spotless.gradle.kts` has been updated to include specific editorConfig settings and target file patterns. The following changes were made:

- Added the following editorConfig settings:
  - `ij_kotlin_allow_trailing_comma_on_call_site` set to "true"
  - `ktlint_standard_function-naming` set to "disabled"
  - `ij_kotlin_allow_trailing_comma` set to "true"
  - `ktlint_experimental` set to "enabled"
  - `ktlint_filename` set to "disabled"
  - `android` set to "true"

- Updated the `kotlinDefault` function to accept a `target` parameter, allowing for more specific file patterns to be targeted. The following changes were made:
  - In the `kotlinGradle` block, the `kotlinDefault` function was updated to target `*.gradle.kts` files.
  - In the `kotlin` block, the `kotlinDefault` function was updated to target `*.kt` files.

These changes were made to improve the Spotless formatting and linting process for Kotlin files in the project.
