### PR TITLE
Elevate Renovate Token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -28,10 +28,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.5.2
 
+      - name: Generate Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          private_key: ${{ secrets.PRIVATE_KEY }}
+          app_id: ${{ secrets.APP_ID }}
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v35.2.0
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'INFO' }}
         with:
           configurationFile: .github/renovate.json
-          token: '${{ secrets.GITHUB_TOKEN }}'
+          token: ${{ steps.generate_token.outputs.token }}

--- a/repositories.gradle.kts
+++ b/repositories.gradle.kts
@@ -12,4 +12,10 @@ pluginManagement {
     }
 
     repositories.default()
+
+    resolutionStrategy.eachPlugin {
+        when (requested.id.id) {
+            "androidx.build.gradle.gcpbuildcache" -> useModule("androidx.build.gradle.gcpbuildcache:gcpbuildcache:${requested.version}")
+        }
+    }
 }

--- a/repositories.gradle.kts
+++ b/repositories.gradle.kts
@@ -12,10 +12,4 @@ pluginManagement {
     }
 
     repositories.default()
-
-    resolutionStrategy.eachPlugin {
-        when (requested.id.id) {
-            "androidx.build.gradle.gcpbuildcache" -> useModule("androidx.build.gradle.gcpbuildcache:gcpbuildcache:${requested.version}")
-        }
-    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ import androidx.build.gradle.gcpbuildcache.GcpBuildCacheServiceFactory
 apply(from = "repositories.gradle.kts")
 
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-beta01"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-beta02"
     id("com.google.cloud.tools.jib") version "3.3.2" apply false
     id("com.gradle.enterprise") version "3.14"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ import androidx.build.gradle.gcpbuildcache.GcpBuildCacheServiceFactory
 apply(from = "repositories.gradle.kts")
 
 plugins {
-    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-beta02"
+    id("androidx.build.gradle.gcpbuildcache") version "1.0.0-beta04"
     id("com.google.cloud.tools.jib") version "3.3.2" apply false
     id("com.gradle.enterprise") version "3.14"
 }


### PR DESCRIPTION
- chore(deps): update plugin androidx.build.gradle.gcpbuildcache to v1.0.0-beta02
- Include resolution strategy for gcpbuildcache without marker artifact
- Revert "Include resolution strategy for gcpbuildcache without marker artifact"
- Execute renovate with elevated access token
