### PR TITLE
feat(terraform): add "Bug" label to the GitHub repository module

### DIFF
--- a/google-cloud/src/main/terraform/modules.tf
+++ b/google-cloud/src/main/terraform/modules.tf
@@ -45,6 +45,11 @@ module "github-repository" {
   description = "Playground"
   labels      = [
     {
+      description = "Indicates an unexpected problem or unintended behavior",
+      color       = "D73A4A"
+      name        = "Bug",
+    },
+    {
       description = "Run Gradle with all task actions disabled"
       name        = "Dry Run"
       color       = "6AFD9F"


### PR DESCRIPTION
The "Bug" label is added to the labels list in the GitHub repository module configuration. This label is used to indicate an unexpected problem or unintended behavior. The label has a description of "Indicates an unexpected problem or unintended behavior" and a color of "D73A4A".
