### PR TITLE
feat(main.tf): add "apigateway.apiconfigs.create" permission to the "actionsPublisher" custom role

### DIFF
--- a/google-cloud/src/main/terraform/main.tf
+++ b/google-cloud/src/main/terraform/main.tf
@@ -10,6 +10,7 @@ resource "google_project_iam_custom_role" "main" {
   provider    = google.impersonated
   role_id     = "actionsPublisher"
   permissions = [
+    "apigateway.apiconfigs.create",
     "artifactregistry.repositories.uploadArtifacts",
     "cloudbuild.builds.create",
     "iam.serviceAccounts.actAs",


### PR DESCRIPTION
The "apigateway.apiconfigs.create" permission was added to the "actionsPublisher" custom role in order to allow the role to create API Gateway configurations. This change was made to provide the necessary permissions for the role to perform the required actions in the system.
