### PR TITLE
feat(terraform): add permission "apigateway.gateways.update" to the custom role "actionsPublisher"

### DIFF
--- a/google-cloud/src/main/terraform/main.tf
+++ b/google-cloud/src/main/terraform/main.tf
@@ -12,6 +12,7 @@ resource "google_project_iam_custom_role" "main" {
   role_id     = "actionsPublisher"
   permissions = [
     "apigateway.apiconfigs.create",
+    "apigateway.gateways.update",
     "artifactregistry.repositories.uploadArtifacts",
     "cloudbuild.builds.create",
     "iam.serviceAccounts.actAs",


### PR DESCRIPTION
The permission "apigateway.gateways.update" is added to the custom role "actionsPublisher" in order to allow the role to update API gateways. This change is necessary to grant the required permissions for the role to perform the necessary actions in the system.
