### PR TITLE
refactor(build-plugins): rename `android` block to `androidTarget` for clarity and consistency fix(gradle.properties): add `android.suppressUnsupportedCompileSdk=34` to suppress unsupported compile SDK warning

### DIFF
--- a/build-plugins/src/main/kotlin/io.ashdavies.android.gradle.kts
+++ b/build-plugins/src/main/kotlin/io.ashdavies.android.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
 
     androidMain.dependencies {
         implementation(libs.androidx.annotation)

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@
 
 # Android
 android.enableBuildConfigAsBytecode=true
+android.suppressUnsupportedCompileSdk=34
 android.uniquePackageNames=true
 android.useAndroidX=true
 


### PR DESCRIPTION
Fixes #455 