### PR TITLE
Terraform Local File

### DIFF
--- a/.github/workflows/google-cloud.yml
+++ b/.github/workflows/google-cloud.yml
@@ -26,11 +26,6 @@ jobs:
   build:
     name: Configure Google Cloud
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Google Cloud'))
-      || (github.event.action == 'labeled' && github.event.label.name == 'Google Cloud')
-      || github.event_name == 'workflow_dispatch'
-      || github.ref == 'refs/heads/main'
 
     permissions:
       pull-requests: 'write'

--- a/google-cloud/src/main/terraform/main.tf
+++ b/google-cloud/src/main/terraform/main.tf
@@ -1,3 +1,9 @@
+locals {
+  openapi_config = templatefile(var.openapi_config, {
+    backend_service_name = module.cloud-run-build.url
+  })
+}
+
 # google_project_service.main is deprecated
 resource "google_project_service" "main" {
   service            = module.cloud-run-endpoint.service_name
@@ -33,11 +39,4 @@ resource "google_project_iam_custom_role" "main" {
     "storage.objects.delete",
     "storage.objects.list",
   ]
-}
-
-resource "local_file" "openapi_config" {
-  content  = templatefile(var.openapi_config, {
-    backend_service_name = module.cloud-run-build.url
-  })
-  filename = basename(var.openapi_config)
 }

--- a/google-cloud/src/main/terraform/modules.tf
+++ b/google-cloud/src/main/terraform/modules.tf
@@ -1,11 +1,10 @@
 module "api-gateway" {
-  openapi_contents = base64encode(local_file.openapi_config.content)
-  openapi_path     = local_file.openapi_config.filename
   source           = "./modules/google/api-gateway"
-  gateway_id       = "playground-api-gateway"
-  region           = var.project_region
   api_id           = "playground-api"
+  gateway_id       = "playground-api-gateway"
+  openapi_contents = base64encode(local.openapi_config)
   project          = var.project_id
+  region           = var.project_region
 }
 
 module "cloud-run-build" {
@@ -18,17 +17,17 @@ module "cloud-run-build" {
 
 # module.cloud-run-endpoint is deprecated
 module "cloud-run-endpoint" {
-  container_image    = "${var.project_region}-docker.pkg.dev/${var.project_id}/endpoints-release/endpoints-runtime-serverless:${var.esp_tag}-${var.service_name}-${module.cloud-run-endpoint.config_id}"
-  image_repository   = "${var.project_region}-docker.pkg.dev/${var.project_id}/endpoints-release"
-  gcloud_build_image = var.resources.gcloud-build-image.path
   source             = "./modules/google/cloud-run-endpoint"
   config_id          = module.cloud-run-endpoint.config_id
-  openapi_config     = local_file.openapi_config.content
+  container_image    = "${var.project_region}-docker.pkg.dev/${var.project_id}/endpoints-release/endpoints-runtime-serverless:${var.esp_tag}-${var.service_name}-${module.cloud-run-endpoint.config_id}"
   endpoint_name      = "playground.ashdavies.dev"
-  service_name       = "playground-endpoint"
-  location           = var.project_region
-  project            = var.project_id
   esp_tag            = var.esp_tag
+  gcloud_build_image = var.resources.gcloud-build-image.path
+  image_repository   = "${var.project_region}-docker.pkg.dev/${var.project_id}/endpoints-release"
+  location           = var.project_region
+  openapi_config     = local.openapi_config
+  project            = var.project_id
+  service_name       = "playground-endpoint"
 }
 
 # module endpoint-iam-binding is deprecated
@@ -65,11 +64,6 @@ module "github-repository" {
       description = "Run Gradle with all task actions disabled"
       name        = "Dry Run"
       color       = "6AFD9F"
-    },
-    {
-      description = "Trigger deployment to Google Cloud"
-      name        = "Google Cloud"
-      color       = "3367d6"
     }
   ]
   secrets = [

--- a/google-cloud/src/main/terraform/versions.tf
+++ b/google-cloud/src/main/terraform/versions.tf
@@ -14,6 +14,11 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 4.0"
     }
+
+    # usage local_file is deprecated
+    local = {
+      source = "hashicorp/local"
+    }
   }
 
   required_version = ">= 0.13"


### PR DESCRIPTION
CI environments are ephemeral, so each run requires a new file to be created, adding noise to the plan output. The goal is to reduce conditional behaviour, so all workflows are executed, and diffs are calculated more accurately.

- Remove `local_file.openapi_config`
- Introduce `locals.openapi_config`
- Remove cloud deployment condition
- Remove google cloud label (unnecessary)