### PR TITLE
chore(versions.tf): remove deprecated local_file module and its configuration

### DIFF
--- a/google-cloud/src/main/terraform/versions.tf
+++ b/google-cloud/src/main/terraform/versions.tf
@@ -14,11 +14,6 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 4.0"
     }
-
-    # usage local_file is deprecated
-    local = {
-      source = "hashicorp/local"
-    }
   }
 
   required_version = ">= 0.13"


### PR DESCRIPTION
The local_file module was deprecated and is no longer needed in the project. This commit removes the configuration for the local_file module from the versions.tf file.
