### PR TITLE
refactor: Update regex manager for Terraform version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,18 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "hashicorp/terraform",
       "depTypeTemplate": "terraform_version",
       "extractVersionTemplate": "v(?<version>.*)",
       "fileMatch": "^\\.github/workflows/.*\\.yml",
-      "matchStrings": ["terraform_version: (?<currentValue>.*)"],
+      "matchStrings": [
+        "terraform_version: (?<currentValue>.*)"
+      ],
       "versioningTemplate": "hashicorp"
     }
   ],
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "gitAuthor": "Playground Manager <126197455+playground-manager[bot]@users.noreply.github.com>",
   "ignoreUnstable": true,
@@ -39,7 +42,7 @@
       "groupName": "Compose Multiplatform",
       "matchPackagePrefixes": [
         "org.jetbrains.compose.compiler",
-        "org.jetbrains.kotlin:kotlin",
+        "org.jetbrains.kotlin:kotlin"
       ]
     },
     {


### PR DESCRIPTION
The `renovate.json` file was modified to update the regex manager for extracting Terraform version information. The customType has been set to "regex" and the matchStrings array has been formatted.
