### PR TITLE
Update renovatebot/github-action to version v39.1.1

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -34,7 +34,7 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
           app_id: ${{ secrets.APP_ID }}
 
-      - uses: renovatebot/github-action@v35.2.0
+      - uses: renovatebot/github-action@v39.1.1
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'INFO' }}
         with:


### PR DESCRIPTION
Update the GitHub Action for renovatebot to the latest version v39.1.1. This update includes bug fixes and improvements.
