### PR TITLE
fix/openapi date library

### DIFF
--- a/http-client/build.gradle.kts
+++ b/http-client/build.gradle.kts
@@ -41,6 +41,7 @@ openApiGenerate {
     inputSpec.set("$rootDir/${property("openapi.generator.inputSpec")}")
     templateDir.set("$projectDir/src/commonMain/resources/templates")
     packageName.set("io.ashdavies.generated")
+    additionalProperties.put("dateLibrary", "kotlinx-datetime")
     serverVariables.put("cloud_run_hostname", String())
     ignoreFileOverride.set("$projectDir/.openapi-generator-ignore")
     configOptions.put("library", "multiplatform")

--- a/http-client/build.gradle.kts
+++ b/http-client/build.gradle.kts
@@ -41,7 +41,7 @@ openApiGenerate {
     inputSpec.set("$rootDir/${property("openapi.generator.inputSpec")}")
     templateDir.set("$projectDir/src/commonMain/resources/templates")
     packageName.set("io.ashdavies.generated")
-    additionalProperties.put("dateLibrary", "kotlinx-datetime")
+    additionalProperties.put("dateLibrary", "string")
     serverVariables.put("cloud_run_hostname", String())
     ignoreFileOverride.set("$projectDir/.openapi-generator-ignore")
     configOptions.put("library", "multiplatform")


### PR DESCRIPTION
- Specify kotlinx datetime as date library
- Use strings for dates as dateLibrary generates unsupported java time
