### PR TITLE
Remove parameter enabled by default

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -10,5 +10,3 @@ runs:
         java-version: 17
 
     - uses: gradle/actions/setup-gradle@v4
-      with:
-        gradle-home-cache-cleanup: true


### PR DESCRIPTION
https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-gradle-home-cache-cleanup-input-parameter-has-been-replaced-by-cache-cleanup