### PR TITLE
refactor: simplify EventListUi implementation and restrict visibility

### DIFF
--- a/conference-app/src/wasmJsMain/kotlin/dev/ashdavies/playground/Main.kt
+++ b/conference-app/src/wasmJsMain/kotlin/dev/ashdavies/playground/Main.kt
@@ -16,7 +16,7 @@ import dev.zacsweers.metro.createGraphFactory
 
 @OptIn(ExperimentalComposeUiApi::class)
 public fun main() {
-    ComposeViewport("ConferenceApp") {
+    ComposeViewport {
         ConferenceApp(PlatformContext)
     }
 }

--- a/conference-app/src/wasmJsMain/resources/index.html
+++ b/conference-app/src/wasmJsMain/resources/index.html
@@ -12,14 +12,9 @@
             width: 100%;
             overflow: hidden;
         }
-        #root {
-            height: 100%;
-            width: 100%;
-        }
     </style>
 </head>
 <body>
-    <canvas id="ComposeTarget"></canvas>
     <script src="conference-app.js"></script>
 </body>
 </html>

--- a/feature/event-list/build.gradle.kts
+++ b/feature/event-list/build.gradle.kts
@@ -41,7 +41,10 @@ kotlin {
 
 metro {
     @OptIn(ExperimentalMetroGradleApi::class)
-    enableCircuitCodegen = true
+    run {
+        enableCircuitCodegen = true
+        generateContributionProviders = true
+    }
 
     warnOnInjectAnnotationPlacement = false
 }

--- a/feature/event-list/src/commonMain/kotlin/dev/ashdavies/playground/event/EventListPresenter.kt
+++ b/feature/event-list/src/commonMain/kotlin/dev/ashdavies/playground/event/EventListPresenter.kt
@@ -18,7 +18,7 @@ import dev.zacsweers.metro.AssistedInject
 
 private const val DEFAULT_PAGE_SIZE = 10
 
-public class EventListPresenter @AssistedInject constructor(
+internal class EventListPresenter @AssistedInject constructor(
     @Assisted private val screen: Screen,
     @Assisted private val navigator: Navigator,
     private val eventPagerFactory: PagerFactory<Long, Event>,

--- a/feature/event-list/src/commonMain/kotlin/dev/ashdavies/playground/event/EventListState.kt
+++ b/feature/event-list/src/commonMain/kotlin/dev/ashdavies/playground/event/EventListState.kt
@@ -3,7 +3,7 @@ package dev.ashdavies.playground.event
 import com.slack.circuit.runtime.CircuitUiState
 import kotlinx.collections.immutable.ImmutableList
 
-public data class EventListState(
+internal data class EventListState(
     val itemList: ImmutableList<dev.ashdavies.playground.event.Event?>,
     val selectedIndex: Int?,
     val isRefreshing: Boolean,
@@ -11,8 +11,8 @@ public data class EventListState(
     val eventSink: (Event) -> Unit,
 ) : CircuitUiState {
 
-    public sealed interface Event {
-        public data class ItemClick(val id: Long) : Event
-        public data object Refresh : Event
+    sealed interface Event {
+        data class ItemClick(val id: Long) : Event
+        data object Refresh : Event
     }
 }

--- a/feature/event-list/src/commonMain/kotlin/dev/ashdavies/playground/event/EventListUi.kt
+++ b/feature/event-list/src/commonMain/kotlin/dev/ashdavies/playground/event/EventListUi.kt
@@ -45,7 +45,6 @@ import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material3.fade
 import com.google.accompanist.placeholder.material3.placeholder
 import com.slack.circuit.codegen.annotations.CircuitInject
-import com.slack.circuit.runtime.ui.Ui
 import dev.ashdavies.playground.material.padding
 import dev.ashdavies.playground.material.spacing
 import dev.ashdavies.playground.material.values
@@ -53,7 +52,6 @@ import dev.ashdavies.playground.ui.CenterAlignedTopAppBar
 import dev.ashdavies.playground.ui.DateRangeBadge
 import dev.ashdavies.playground.ui.DateRangeBadgeState
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.Inject
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.daysUntil
@@ -65,55 +63,52 @@ import playground.feature.event_list.generated.resources.online_only
 import playground.feature.event_list.generated.resources.upcoming_events
 import kotlin.time.Clock
 
+@Composable
 @CircuitInject(EventScreen.List::class, AppScope::class)
-public class EventListUi @Inject constructor() : Ui<EventListState> {
+internal fun EventListUi(state: EventListState, modifier: Modifier) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            @OptIn(ExperimentalMaterial3Api::class)
+            CenterAlignedTopAppBar(stringResource(Res.string.upcoming_events))
+        },
+    ) { contentPadding ->
+        PullToRefreshBox(
+            isRefreshing = state.isRefreshing,
+            onRefresh = { state.eventSink(EventListState.Event.Refresh) },
+            modifier = Modifier.padding(contentPadding),
+        ) {
+            if (state.errorMessage != null) {
+                EventFailure(state.errorMessage)
+            }
 
-    @Composable
-    override fun Content(state: EventListState, modifier: Modifier) {
-        Scaffold(
-            modifier = modifier,
-            topBar = {
-                @OptIn(ExperimentalMaterial3Api::class)
-                CenterAlignedTopAppBar(stringResource(Res.string.upcoming_events))
-            },
-        ) { contentPadding ->
-            PullToRefreshBox(
-                isRefreshing = state.isRefreshing,
-                onRefresh = { state.eventSink(EventListState.Event.Refresh) },
-                modifier = Modifier.padding(contentPadding),
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = MaterialTheme.spacing.large.values,
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.large.vertical),
             ) {
-                if (state.errorMessage != null) {
-                    EventFailure(state.errorMessage)
-                }
+                itemsIndexed(state.itemList) { index, item ->
+                    val itemModifier = Modifier
+                        .animateItem()
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
 
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = MaterialTheme.spacing.large.values,
-                    verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.large.vertical),
-                ) {
-                    itemsIndexed(state.itemList) { index, item ->
-                        val itemModifier = Modifier
-                            .animateItem()
-                            .fillMaxWidth()
-                            .clip(MaterialTheme.shapes.medium)
+                    when {
+                        item != null -> EventItemContent(
+                            event = item,
+                            isSelected = index == state.selectedIndex,
+                            modifier = itemModifier
+                                .clickable {
+                                    state.eventSink(EventListState.Event.ItemClick(item.id))
+                                }
+                                .paint(rememberBackgroundPainter(item.imageUrl)),
+                        )
 
-                        when {
-                            item != null -> EventItemContent(
-                                event = item,
-                                isSelected = index == state.selectedIndex,
-                                modifier = itemModifier
-                                    .clickable {
-                                        state.eventSink(EventListState.Event.ItemClick(item.id))
-                                    }
-                                    .paint(rememberBackgroundPainter(item.imageUrl)),
-                            )
-
-                            else -> EventItemContent(
-                                event = null,
-                                isSelected = false,
-                                modifier = itemModifier,
-                            )
-                        }
+                        else -> EventItemContent(
+                            event = null,
+                            isSelected = false,
+                            modifier = itemModifier,
+                        )
                     }
                 }
             }


### PR DESCRIPTION
- Convert `EventListUi` from a class-based implementation to a functional `@Composable` using `@CircuitInject`.
- Update visibility of `EventListState`, `EventListPresenter`, and `EventListUi` to `internal`.
- Enable `generateContributionProviders` in the Metro configuration for the event-list feature.
- Remove redundant canvas element and styling from the Wasm `index.html`.
- Simplify `ComposeViewport` initialization in the Wasm `Main.kt`.